### PR TITLE
Fix Input_thread Bugs and Semaphore Optimization (already passed test on Oracle Cloud)

### DIFF
--- a/config.h
+++ b/config.h
@@ -133,8 +133,8 @@
 #define PARTITIONED 0
 #define REPLICATED 1
 // To select the amount of time to warmup and run.
-#define DONE_TIMER 1 * 60 * BILLION
-#define WARMUP_TIMER  30 * BILLION
+#define DONE_TIMER 1 * 15 * BILLION
+#define WARMUP_TIMER  5 * BILLION
 // Select the consensus algorithm to run.
 #define CONSENSUS PBFT
 #define PBFT 2

--- a/config.h
+++ b/config.h
@@ -1,7 +1,7 @@
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 // Specify the number of servers or replicas
-#define NODE_CNT 4
+#define NODE_CNT 7
 // Number of worker threads at primary. 
 #define THREAD_CNT 5 // This Should be the sum of following thread count + protocol specifig threads
 #define WORKER_THREAD_CNT 1

--- a/config.h
+++ b/config.h
@@ -1,7 +1,7 @@
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 // Specify the number of servers or replicas
-#define NODE_CNT 7
+#define NODE_CNT 4
 // Number of worker threads at primary. 
 #define THREAD_CNT 5 // This Should be the sum of following thread count + protocol specifig threads
 #define WORKER_THREAD_CNT 1
@@ -133,8 +133,8 @@
 #define PARTITIONED 0
 #define REPLICATED 1
 // To select the amount of time to warmup and run.
-#define DONE_TIMER 1 * 15 * BILLION
-#define WARMUP_TIMER  5 * BILLION
+#define DONE_TIMER 1 * 60 * BILLION
+#define WARMUP_TIMER  30 * BILLION
 // Select the consensus algorithm to run.
 #define CONSENSUS PBFT
 #define PBFT 2

--- a/system/global.cpp
+++ b/system/global.cpp
@@ -6,6 +6,7 @@
 #include "client_query.h"
 #include "transport.h"
 #include "work_queue.h"
+#include "sema_manager.h"
 
 #include "msg_queue.h"
 #include "pool.h"
@@ -29,6 +30,8 @@ QWorkQueue work_queue;
 
 MessageQueue msg_queue;
 Client_txn client_man;
+
+SemaphoreManager semamanager;
 
 bool volatile warmup_done = false;
 bool volatile enable_thread_mem_pool = false;
@@ -220,6 +223,10 @@ uint64_t get_expectedExecuteCount()
 void set_expectedExecuteCount(uint64_t val)
 {
 	expectedExecuteCount = val;
+	semamanager.emheap.pop();	//remvoe the last executed msg from the heap
+	if(val == semamanager.emheap.top()){	//check whether the next msg to execute has been in the heap 
+		semamanager.post(SpecialSemaphore(EXECUTE), false, false);
+	}
 }
 
 // Variable used by all threads during setup, to mark they are ready

--- a/system/global.h
+++ b/system/global.h
@@ -30,6 +30,7 @@
 #include "pool.h"
 #include "txn_table.h"
 #include "sim_manager.h"
+#include "sema_manager.h"
 #include <mutex>
 
 #include <unordered_map>
@@ -44,6 +45,7 @@ using namespace std;
 class mem_alloc;
 class Stats;
 class SimManager;
+class SemaphoreManager;
 class Query_queue;
 class Transport;
 class Remote_query;
@@ -72,6 +74,7 @@ typedef uint64_t ts_t; // time stamp type
 extern mem_alloc mem_allocator;
 extern Stats stats;
 extern SimManager *simulation;
+extern SemaphoreManager semamanager;
 extern Query_queue query_queue;
 extern Client_query_queue client_query_queue;
 extern Transport tport_man;

--- a/system/io_thread.cpp
+++ b/system/io_thread.cpp
@@ -155,7 +155,7 @@ RC InputThread::client_recv_loop()
     while (!simulation->is_done())
     {
         heartbeat();
-        msgs = tport_man.recv_msg(get_thd_id() - g_thread_cnt);
+        msgs = tport_man.recv_msg(get_thd_id());
         if (msgs == NULL)
         {
 
@@ -333,7 +333,7 @@ RC InputThread::server_recv_loop()
         heartbeat();
 
 
-        msgs = tport_man.recv_msg(get_thd_id());
+        msgs = tport_man.recv_msg(get_thd_id() - g_thread_cnt);
 
         if (msgs == NULL)
         {

--- a/system/io_thread.cpp
+++ b/system/io_thread.cpp
@@ -369,6 +369,9 @@ RC InputThread::server_recv_loop()
         }
         delete msgs;
     }
+
+    semamanager.post_all();
+
     // cout << "Input: " << _thd_id << " :: " << (starttime * 1.0) / BILLION << "\n";
     input_thd_idle_time[_thd_id - g_thread_cnt] = starttime;
     fflush(stdout);
@@ -399,9 +402,28 @@ void OutputThread::setup()
     commonVar++;
     batchMTX.unlock();
     messager->idle_starttime = 0;
-    while (!simulation->is_setup_done())
-    {
-        messager->run();
+
+    if(ISSERVER){
+        uint64_t td_id = io_thd_id % g_this_send_thread_cnt;
+        while (!simulation->is_setup_done())
+        {
+            // One replica needs to send 1 INIT_DONE and 2 KEYEX msgs to any other replica
+            if(semamanager.get_init_msg_cnt(td_id) == 0){   
+                // After sending all the msgs, a replica waits until it has received
+                // INIT_DONE msgs from all other replicas and clients.
+                // Otherwise, a deadlock may appear
+                semamanager.wait(SpecialSemaphore(SETUP_DONE), false, false);
+                break;
+            }
+            messager->run();
+            semamanager.dec_init_msg_cnt(td_id);
+        }
+    }
+    else{
+        while (!simulation->is_setup_done())
+        {
+            messager->run();
+        }
     }
 }
 

--- a/system/io_thread.cpp
+++ b/system/io_thread.cpp
@@ -63,7 +63,11 @@ void InputThread::setup()
     std::vector<Message *> *msgs;
     while (!simulation->is_setup_done())
     {
-        msgs = tport_man.recv_msg(get_thd_id());
+        if(ISSERVER)
+            msgs = tport_man.recv_msg(get_thd_id() - g_thread_cnt);
+        else
+            msgs = tport_man.recv_msg(get_thd_id());
+
         if (msgs == NULL)
             continue;
 
@@ -151,7 +155,7 @@ RC InputThread::client_recv_loop()
     while (!simulation->is_done())
     {
         heartbeat();
-        msgs = tport_man.recv_msg(get_thd_id());
+        msgs = tport_man.recv_msg(get_thd_id() - g_thread_cnt);
         if (msgs == NULL)
         {
 

--- a/system/main.cpp
+++ b/system/main.cpp
@@ -10,6 +10,7 @@
 #include "msg_queue.h"
 #include "ycsb_query.h"
 #include "sim_manager.h"
+#include "sema_manager.h"
 #include "work_queue.h"
 #include "client_query.h"
 #include "crypto.h"
@@ -67,6 +68,12 @@ int main(int argc, char *argv[])
     printf("Initializing transport manager... ");
     fflush(stdout);
     tport_man.init();
+    printf("Done\n");
+    fflush(stdout);
+
+    printf("Initializing semaphore manager... ");
+    fflush(stdout);
+    semamanager.init();
     printf("Done\n");
     fflush(stdout);
 

--- a/system/msg_queue.cpp
+++ b/system/msg_queue.cpp
@@ -197,12 +197,13 @@ void MessageQueue::enqueue(uint64_t thd_id, Message *msg, const vector<uint64_t>
             while (!m_queue[j]->push(entry2) && !simulation->is_done())
             {
             }
+
+            if(ISSERVER)
+                // After a msg is enqueued, increase the value of output_semaphore by 1
+                semamanager.post(j, true);
+
             INC_STATS(thd_id, msg_queue_enq_cnt, 1);
         }
-
-        if(ISSERVER)
-            // After a msg is enqueued, increase the value of output_semaphore by 1
-            semamanager.post(j, true);
 
         // Putting in queue of the last output thread.
         for (uint64_t i = 0; i < dest.size(); i++)

--- a/system/msg_queue.cpp
+++ b/system/msg_queue.cpp
@@ -149,6 +149,12 @@ void MessageQueue::enqueue(uint64_t thd_id, Message *msg, const vector<uint64_t>
         while (!m_queue[rand]->push(entry) && !simulation->is_done())
         {
         }
+
+        if(ISSERVER){
+            // After a msg is enqueued, increase the value of output_semaphore by 1
+            semamanager.post(rand, true);
+        }
+
         INC_STATS(thd_id, msg_queue_enq_cnt, 1);
         break;
     }
@@ -194,6 +200,10 @@ void MessageQueue::enqueue(uint64_t thd_id, Message *msg, const vector<uint64_t>
             INC_STATS(thd_id, msg_queue_enq_cnt, 1);
         }
 
+        if(ISSERVER)
+            // After a msg is enqueued, increase the value of output_semaphore by 1
+            semamanager.post(j, true);
+
         // Putting in queue of the last output thread.
         for (uint64_t i = 0; i < dest.size(); i++)
         {
@@ -203,6 +213,11 @@ void MessageQueue::enqueue(uint64_t thd_id, Message *msg, const vector<uint64_t>
         while (!m_queue[j]->push(entry) && !simulation->is_done())
         {
         }
+
+        if(ISSERVER)
+            // After a msg is enqueued, increase the value of output_semaphore by 1
+            semamanager.post(j, true);
+
         INC_STATS(thd_id, msg_queue_enq_cnt, 1);
 
         delete_msg_buffer(buf);

--- a/system/sema_manager.cpp
+++ b/system/sema_manager.cpp
@@ -1,0 +1,137 @@
+#include "global.h"
+#include "sema_manager.h"
+
+void ExecuteMsgHeap::push(uint64_t txn_id){
+    heap_lock.lock();
+    heap.push(txn_id);
+    heap_lock.unlock();
+}
+
+uint64_t ExecuteMsgHeap::top(){
+    uint64_t value = 0;
+	heap_lock.lock();
+	value = heap.top();
+	heap_lock.unlock();
+    return value;
+}
+
+void ExecuteMsgHeap::pop(){
+    heap_lock.lock();
+    heap.pop();
+    heap_lock.unlock();
+}
+
+void SemaphoreManager::init(){
+    worker_queue_semaphore = new sem_t[THREAD_CNT];
+    output_semaphore = new sem_t[SEND_THREAD_CNT];
+    for(uint i = 0; i < THREAD_CNT; i++){
+        sem_init(&worker_queue_semaphore[i], 0, 0);
+    }
+
+    for(uint i = 0; i < SEND_THREAD_CNT; i++){
+        sem_init(&output_semaphore[i], 0, 0);
+    }
+
+    sem_init(&execute_semaphore, 0, 0);
+    sem_init(&setup_done_barrier, 0, 0);
+    
+#if CONSENSUS == HOTSTUFF
+    #if !PVP 
+        if(g_node_id==0)
+            sem_init(&new_txn_semaphore, 0, 1); // Initially, replica 0 is the primary
+        else
+            sem_init(&new_txn_semaphore, 0, 0);
+    #else
+        sem_init(&new_txn_semaphore, 0, 1); // Initially, each replica is primary of one instance
+    #endif
+#endif
+
+    init_msg_cnt = new uint64_t[SEND_THREAD_CNT];
+    for(uint i = 0; i < g_node_cnt; i++){
+        if(i == g_node_id)
+            continue;
+        init_msg_cnt[i%SEND_THREAD_CNT] += 3;
+    }
+}
+
+
+void SemaphoreManager::wait(uint32_t thd_id, bool is_output_queue, bool is_worker_queue){
+    if(is_output_queue){
+        sem_wait(&output_semaphore[thd_id]);
+    }
+    else if(is_worker_queue){
+        // Wait until there is at least one msg in its corresponding queue
+        sem_wait(&worker_queue_semaphore[thd_id]);
+#if CONSENSUS == HOTSTUFF
+        // The batch_thread waits until the replica becomes primary of at least one instance 
+        if(thd_id == g_thread_cnt - 1 - g_checkpointing_thread_cnt - g_execution_thread_cnt)   
+            sem_wait(&new_txn_semaphore);
+#endif
+        // The execute_thread waits until the next msg to execute is enqueued
+        if (thd_id == g_thread_cnt - 1)  
+            sem_wait(&execute_semaphore);
+    }
+    else{
+        switch(thd_id){
+            case SETUP_DONE:{
+                sem_wait(&setup_done_barrier);
+                break;
+            }
+            default:{
+                assert(0);
+            }
+        }
+    }
+}
+
+void SemaphoreManager::post(uint32_t thd_id, bool is_output_queue, bool is_worker_queue){
+    if(is_output_queue){
+        sem_post(&output_semaphore[thd_id]);
+    }
+    else if(is_worker_queue){
+        sem_post(&worker_queue_semaphore[thd_id]);
+    }else{
+        switch(thd_id){
+#if CONSENSUS == HOTSTUFF
+            case NEW_TXN:{
+                sem_post(&new_txn_semaphore);
+                break;
+            }
+#endif
+            case EXECUTE:{
+                sem_post(&execute_semaphore);
+                break;
+            }
+            case SETUP_DONE:{
+                sem_post(&setup_done_barrier);
+                break;
+            }
+            default:{
+                assert(0);
+            }
+        }
+    }
+}
+
+void SemaphoreManager::post_all(){
+    // After simulation is done, sem_post all sempahores
+    // Otherwise, some threads may be stalled by sem_wait()
+    for(uint i=0; i<g_thread_cnt; i++){
+        sem_post(&worker_queue_semaphore[i]);
+    }
+    for(uint i=0; i<g_this_send_thread_cnt; i++){
+        sem_post(&output_semaphore[i]);
+    }
+#if CONSENSUS == HOTSTUFF
+    sem_post(&new_txn_semaphore);
+#endif
+    sem_post(&execute_semaphore);
+}
+
+void SemaphoreManager::dec_init_msg_cnt(uint64_t td_id){
+    init_msg_cnt[td_id]--;
+}
+    
+uint64_t SemaphoreManager::get_init_msg_cnt(uint64_t td_id){
+    return init_msg_cnt[td_id];
+}

--- a/system/sema_manager.cpp
+++ b/system/sema_manager.cpp
@@ -47,6 +47,9 @@ void SemaphoreManager::init(){
 #endif
 
     init_msg_cnt = new uint64_t[SEND_THREAD_CNT];
+    for(uint i = 0; i < SEND_THREAD_CNT; i++){
+        init_msg_cnt[i] = 0;
+    }
     for(uint i = 0; i < g_node_cnt; i++){
         if(i == g_node_id)
             continue;

--- a/system/sema_manager.cpp
+++ b/system/sema_manager.cpp
@@ -50,7 +50,7 @@ void SemaphoreManager::init(){
     for(uint i = 0; i < SEND_THREAD_CNT; i++){
         init_msg_cnt[i] = 0;
     }
-    for(uint i = 0; i < g_node_cnt; i++){
+    for(uint i = 0; i < g_total_node_cnt; i++){
         if(i == g_node_id)
             continue;
         init_msg_cnt[i%SEND_THREAD_CNT] += 3;

--- a/system/sema_manager.h
+++ b/system/sema_manager.h
@@ -1,0 +1,59 @@
+#ifndef _SEMAMAN_H_
+#define _SEMAMAN_H_
+
+#include "global.h"
+#include <mutex>
+#include <semaphore.h>
+#include <vector>
+
+enum SpecialSemaphore{
+#if CONSENSUS == HOTSTUFF
+    NEW_TXN,
+#endif
+    EXECUTE,
+    SETUP_DONE
+};
+
+class ExecuteMsgHeap{
+public:
+    // A min heap storing txn_id of execute_msgs
+    std::priority_queue<uint64_t , std::vector<uint64_t>, std::greater<uint64_t> > heap;
+    std::mutex heap_lock;
+    ExecuteMsgHeap(){}
+    void push(uint64_t txn_id);
+    uint64_t top();
+    void pop();
+};
+
+class SemaphoreManager{
+public:
+    // Entities for semaphore optimizations. The value of the semaphores means 
+    // the number of msgs in the corresponding queues of the worker_threads.
+    // Only worker_threads with msgs in their queues will be allocated with CPU resources.
+    sem_t *worker_queue_semaphore;
+#if CONSENSUS == HOTSTUFF
+    // new_txn_semaphore is the number of instances that a replica is primary and has not sent a prepare msg.
+    sem_t new_txn_semaphore;
+#endif
+    // execute_semaphore is whether the next msg to execute has been in the queue.
+    sem_t execute_semaphore;
+    // Entities for semaphore opyimizations on output_thread. The output_thread will be not allocated
+    // with CPU resources until there is a msg in its queue.
+    sem_t *output_semaphore;
+    // Semaphore indicating whether the setup is done
+    sem_t setup_done_barrier;
+
+    // The number of INIT_DONE and KEYEX msgs that each output_thread needs to send.
+    uint64_t *init_msg_cnt;
+
+    // A min-heap storing the txn_id of execute msgs enqueued
+    ExecuteMsgHeap emheap;
+
+    void init();
+    void dec_init_msg_cnt(uint64_t td_id);
+    uint64_t get_init_msg_cnt(uint64_t td_id);
+    void wait(uint32_t thd_id, bool is_output_queue = false, bool is_worker_queue = true);
+    void post(uint32_t thd_id, bool is_output_queue = false, bool is_worker_queue = true);
+    void post_all();
+};
+#endif

--- a/system/sim_manager.cpp
+++ b/system/sim_manager.cpp
@@ -92,6 +92,8 @@ void SimManager::process_setup_msg()
     if (rsp_left == 0)
     {
         set_setup_done();
+        for(uint i = 0; i < SEND_THREAD_CNT; i++)
+            semamanager.post(SpecialSemaphore(SETUP_DONE), false, false);
     }
 }
 

--- a/transport/msg_thread.cpp
+++ b/transport/msg_thread.cpp
@@ -57,6 +57,17 @@ void MessageThread::run()
     // Relative Id of the server's output thread.
     UInt32 td_id = _thd_id % g_this_send_thread_cnt;
 
+    if(ISSERVER){
+        if (simulation->is_warmup_done()){
+            idle_starttime = get_sys_clock();
+        }
+        // Wait until there is a msg in the queue (the value of the semaphore is not zero), then decrease the value by 1
+        semamanager.wait(td_id, true);
+        if (idle_starttime > 0 && simulation->is_warmup_done()){
+            output_thd_idle_time[td_id] += get_sys_clock() - idle_starttime;
+        }    
+    } 
+
     dest = msg_queue.dequeue(get_thd_id(), allsign, msg);
 
     if (!msg)

--- a/transport/msg_thread.cpp
+++ b/transport/msg_thread.cpp
@@ -73,17 +73,9 @@ void MessageThread::run()
     if (!msg)
     {
         check_and_send_batches();
-        if (idle_starttime == 0)
-        {
-            idle_starttime = get_sys_clock();
-        }
         return;
     }
-    if (idle_starttime > 0 && simulation->is_warmup_done())
-    {
-        output_thd_idle_time[td_id] += get_sys_clock() - idle_starttime;
-        idle_starttime = 0;
-    }
+
     assert(msg);
 
     for (uint64_t i = 0; i < dest.size(); i++)

--- a/transport/transport.cpp
+++ b/transport/transport.cpp
@@ -372,6 +372,8 @@ std::vector<Message *> *Transport::recv_msg(uint64_t thd_id)
         else
         {
             uint64_t abs_tid = thd_id % (g_rem_thread_cnt - 1);
+            if(!recv_sockets_servers[abs_tid].size())
+                return msgs;
             ctr = get_next_socket(thd_id, recv_sockets_servers[abs_tid].size());
         }
     }


### PR DESCRIPTION
### Chapter 1 FIX InputThread Bugs
I have found two bugs in the transport module of our system and fixed them.

### 1

As we all know, if we have **_t_** input_threads, only one of them receives msgs from clients, while other **_t-1_** input_threads receive msgs from other replicas.

Usually, we only use 2 InputThreads, and our system works well.

However, there is a bug behind it.

When I want to increase the number of the input_threads from 2 to 3, something wrong but reproducible appears. It seems that the replicas always cannot receive msgs from some other replicas.

Let me give an example to further illustrate this problem and explain the reason behind it.

We run PBFT, and part of the config.h is:

```c++
#define NODE_CNT 7
#define THREAD_CNT 5
#define REM_THREAD_CNT 3
#define CLIENT_NODE_CNT 1
```

Thus, the thd_id of the 3 input_threads are 5, 6, 7, respectively.

For **replica 0**, according to the code below, 

the sockets of replicas 2,4,6 are pushed into recv_sockets_servers[0],

the sockets of replicas 1,3,5 are pushed into recv_sockets_servers[1].

```c++
void Transport::init(){
  	
  	//omitted
  
    for (uint64_t node_id = 0; node_id < g_total_node_cnt; node_id++)
    {
				//omitted
        recv_sockets_servers[node_id % (g_rem_thread_cnt - 1)].push_back(sock);
       // omitted
    }

    fflush(stdout);
}
```

According to the code below, thread 6 listens to client sockets since 6 % 3 == 0.

The other 2 input_threads, thread 5 and 7, all listen to sockets in recv_sockets_servers[1], since 5 % 2 == 1 and 7 % 2 == 1.

Thus, this is the problem, no input_thread listens to sockets in recv_sockets_servers[0], which are for replicas 2, 4, 6.

```c++
// Listens to sockets for messages from other nodes

std::vector<Message *> *Transport::recv_msg(uint64_t thd_id)

{
 		// omitted
    {
        // One thread manages client sockets, while others handles server sockets.
        if (thd_id % g_this_rem_thread_cnt == 0)
        {
            ctr = get_next_socket(thd_id, recv_sockets_clients.size());
        }
        else
        {
            uint64_t abs_tid = thd_id % (g_rem_thread_cnt - 1);
            ctr = get_next_socket(thd_id, recv_sockets_servers[abs_tid].size());
        }
    }
 		// omitted

    return msgs;
}
```

To fix this bug, I made a change to the code. Instead of using the thd_id as the parameter, I use get_thd_id() - g_thread_cnt.

For example, 5==>0, 6==>1.


### 2

A divide-by-zero exception will appear when **_n<2(t-1)_**, in which **_n_** is the number of replicas and **_t_** is the number of input_threads.

Let me give an example to further illustrate this problem and explain the reason behind it.

We run PBFT, and part of the config.h is:

```c++
#define NODE_CNT 7
#define THREAD_CNT 5
#define REM_THREAD_CNT 5
#define CLIENT_NODE_CNT 1
```

Thus, the thd_id of the 5 input_threads are 5, 6, 7, 8, 9 respectively.

For **replica 3,** according to the code below, 

the sockets of replicas 0, 4 are pushed into recv_sockets_servers[0],

the sockets of replicas 1, 5 are pushed into recv_sockets_servers[1],

the sockets of replicas 2, 6 are pushed into recv_sockets_servers[2],

no socket is pushed into recv_sockets_servers[3], which means that input_thread 8 listens to no socket, since (8-5)%4==3.

```c++
void Transport::init(){
	//omitted
  
	for (uint64_t node_id = 0; node_id < g_total_node_cnt; node_id++)
	{
			//omitted
    	recv_sockets_servers[node_id % (g_rem_thread_cnt - 1)].push_back(sock);
   	  // omitted
	}

	fflush(stdout);
}
```
According to the code below, thread 8 calls method **get_next_socket**, but the second parameter is 0. Thus, a divide-by-0 exception will appear, and then the replica 3 cannot work.

```c++
// Listens to sockets for messages from other nodes

std::vector<Message *> *Transport::recv_msg(uint64_t thd_id)

{
 		// omitted
    {
        // One thread manages client sockets, while others handles server sockets.
        if (thd_id % g_this_rem_thread_cnt == 0)
        {
            ctr = get_next_socket(thd_id, recv_sockets_clients.size());
        }
        else
        {
            uint64_t abs_tid = thd_id % (g_rem_thread_cnt - 1);
            ctr = get_next_socket(thd_id, recv_sockets_servers[abs_tid].size());
        }
    }
 		// omitted

    return msgs;
}

uint64_t get_next_socket(uint64_t tid, uint64_t size)
{
	uint64_t abs_tid = tid % g_this_rem_thread_cnt;
	uint64_t nsock = (sock_ctr[abs_tid] + 1) % size;
	sock_ctr[abs_tid] = nsock;
	return nsock;
}

```

To fix this bug, I made a change to the code. The input_thread will check whether the size is 0 before it calls the method.



### Chapter 2 Semaphore Optimization

### Introduction

In order to enable resilientdb replicas to make use of CPU resources more efficiently, I have introduced a new module called "Semaphore Manager". 



### The Problem of the Original Design

As we all know, in resilientdb, we have 3 Thread classes of threads, which are InputThread, OutputThread, and WorkerThread.

For both OutputThread and WorkerThread, their void run() method works like this:

**Step1: Try to dequeue a message from its corresponding queue until simulation is done.**

**Step2: If a msg is dequeued, go to Step3, else go back to Step 1.**

**Step3: Process the msg or send the msg, then go back to Step 1.**

The problem is, even if there is no msg in its corresponding queue, a thread still keeps trying to dequeue a msg, which wastes a lot of CPU resources. This is not a big problem when the number of CPUs is greater than that of threads. However, in protocol such as RCC and PVP, which requires many of CPU threads because of multiple instances, such a design can have an impressionable negative impact on the performance of the system. That is because whether a thread is allocated with CPU resources is not determined by whether it has msgs to process. A lot of CPU resources is wasted, and the threads with msgs to process cannot get CPU resources in time.



### An Effective Solution

If the worker_threads and output_threads are allocated with CPU resources only when there is at least one msg to process in their queues, which can be implemented with counting semaphores. (If you don't know how semaphore works, this link may help you: https://www.geeksforgeeks.org/semaphores-in-process-synchronization/)

Each worker_thread or output_thread has one semaphore. The value of a semaphore is the number of msgs to process in a thread's corresponding queues, initially one.

For example, 

Thread 0 is a worker_thread, and it has one sempahore ***X***, one corresponding queue, ***Q***.

Thread 0 runs, then it is stalled when it calls method wait(***X***), since the value of ***X*** is 0.

Then another thread pushes a msg  into ***Q***, calls post(***X***) to increase the value of ***X*** by 1.

Then, thread 0 can go on, pop the msg just pushed and process it, decreasing the value of ***X*** by 1.

While thread 0 is processing the first msg, another 2 msgs are pushed into ***Q***, the value of ***X*** becomes 2.

After processing the first msg, thread 0 goes back to the beginning of its loop. This time, it will not stalled since the value of ***X*** is not 0.



### Implementation

##### enum SpecialSemaphore

```c++
enum SpecialSemaphore{
    EXECUTE,
    SETUP_DONE
};
```

There are two kinds of special semaphore. I will explain why later in this article.



##### class ExecuteMsgHeap

```c++
class ExecuteMsgHeap{
public:
    // A min heap storing txn_id of execute_msgs
    std::priority_queue<uint64_t , std::vector<uint64_t>, std::greater<uint64_t> > heap;
    std::mutex heap_lock;
    ExecuteMsgHeap(){}
    void push(uint64_t txn_id);
    uint64_t top();
    void pop();
};
```

As we all know, the execute_thread has 2 * g_client_node_cnt * g_inflight_max corresponding queues. And it cannot successfully dequeue a msg unless the next msg to execute has already been enqueued. Thus, with merely one semaphore ***X*** indicating the number of msgs in its corresponding queues, the execute thread can still waste CPU resources. Therefore, the execute_thread needs one more semaphore **Y** indicating whether the next msg to execute has been enqueued. 

In the beginning of its loop, the execute_thread will wait(***X***) first and then wait(**Y**). 

We can store the txn_id of the execute msgs in a min-heap. When the value of the heap top is equal to that of the next msg to process, the value of **Y** increases by one. We can do this when calling the method ***void set_expectedExecuteCount(uint64_t val)*** and pushing an execute msg into an execution_queue.

```c++
void set_expectedExecuteCount(uint64_t val)
{
  expectedExecuteCount = val;
	semamanager.emheap.pop();   //remvoe the last executed msg from the heap
	if(val == semamanager.emheap.top()){    //check whether the next msg to execute has been in the heap 
		semamanager.post(SpecialSemaphore(EXECUTE), false, false);
	}
}

void QWorkQueue::enqueue(uint64_t thd_id, Message *msg, bool busy)
{
	//ommitted
    else if (msg->rtype == EXECUTE_MSG)
    {
        // Execution Map using [indexSize] queues
        uint64_t queue_id = (msg->txn_id / get_batch_size()) % indexSize;
        push_to_queue(entry, execution_queues[queue_id]);
        semamanager.post(g_thread_cnt - 1);
        semamanager.emheap.push(msg->txn_id);
        //if the next msg to execute is enqueued
        if(msg->txn_id == get_expectedExecuteCount()){
            semamanager.post(SpecialSemaphore(EXECUTE), false, false);
        }
    }
  //omitted
}
```



##### Class SemaphoreManager

```c++
class SemaphoreManager{
public:
    // Entities for semaphore optimizations. The value of the semaphores means 
    // the number of msgs in the corresponding queues of the worker_threads.
    // Only worker_threads with msgs in their queues will be allocated with CPU resources.
    sem_t *worker_queue_semaphore;
    // execute_semaphore is whether the next msg to execute has been in the queue.
    sem_t execute_semaphore;
    // Entities for semaphore opyimizations on output_thread. The output_thread will be not allocated
    // with CPU resources until there is a msg in its queue.
    sem_t *output_semaphore;
    // Semaphore indicating whether the setup is done
    sem_t setup_done_barrier;
    // The number of INIT_DONE and KEYEX msgs that each output_thread needs to send.
    uint64_t *init_msg_cnt;
		// A min-heap storing the txn_id of execute msgs enqueued
    ExecuteMsgHeap emheap;

    void init();
    void dec_init_msg_cnt(uint64_t td_id);
    uint64_t get_init_msg_cnt(uint64_t td_id);
    void wait(uint32_t thd_id, bool is_output_queue = false, bool is_worker_queue = true);
    void post(uint32_t thd_id, bool is_output_queue = false, bool is_worker_queue = true);
    void post_all();
};
```



The pointer **worker_queue_semaphore** points to semaphores for WorkerThreads.

The **execute_semaphore** indicates whether the next msg to execute has been in the queue, as mentioned above.

The pointer **output_semaphore** points to semaphores for OutputThreads.

The **emheap** is just the min-heap.

Let me explain why we need the pointer **init_msg_cnt** and the semaphore **setup_done_barrier**.

As we all know, when setting up, the output_threads need to send INIT_DONE msgs and KEYEX msgs. And **simulation->is_setup_done()** returns true after a replica has received INIT_DONE msgs from all other replicas and clients. An output_thread calls **messager->run()** if the replica has not received enough INIT_DONE msgs, even if the has sent all of the INIT_DONE and KEYEX msgs that it should send. Since we have semaphore optimization, the output_thread will be stalled by its semaphore. The key point is, at the same time, other threads, such as other worker_threads and the input_threads, are stalled by the pthread_barrier in line 16, which is a deadlock.

```c++
void OutputThread::setup()
{
		// omitted
    while (!simulation->is_setup_done())
    {
        messager->run();		// line 6
    }
}

void Thread::tsetup()
{
		//omitted
    setup();
    printf("Running %ld:%ld\n", _node_id, _thd_id);
    fflush(stdout);
    pthread_barrier_wait(&warmup_bar);	// line 16
		//omiitted
}
```

To solve this problem, I come up with a solution. 

First, calculate the number of INIT_DONE and KEY msgs that each output_thread needs to send.

Second, make the output_threads wait after sending the INIT_DONE and KEY msgs, until the replica has received INIT_DONE msgs from all other replicas and clients.

```c++
//First, calculate the number of INIT_DONE and KEY msgs that each output_thread needs to send.
void SemaphoreManager::init(){
		// omiiteed
    init_msg_cnt = new uint64_t[SEND_THREAD_CNT];
    for(uint i = 0; i < g_node_cnt; i++){
        if(i == g_node_id)
            continue;
        init_msg_cnt[i%SEND_THREAD_CNT] += 3;
    }
}


//Second, make the output_threads wait after sending the INIT_DONE and KEY msgs, until the replica has received INIT_DONE msgs from all other replicas and clients.
void SimManager::process_setup_msg()
{
    uint64_t rsp_left = ATOM_SUB_FETCH(rsp_cnt, 1);
    if (rsp_left == 0)
    {
        set_setup_done();
        for(uint i = 0; i < SEND_THREAD_CNT; i++)
            semamanager.post(SpecialSemaphore(SETUP_DONE), false, false);
    }
}

void OutputThread::setup()
{
		//omitted
    if(ISSERVER){
        uint64_t td_id = io_thd_id % g_this_send_thread_cnt;
        while (!simulation->is_setup_done())
        {
            // One replica needs to send 1 INIT_DONE and 2 KEYEX msgs to any other replica
            if(semamanager.get_init_msg_cnt(td_id) == 0){   
                // After sending all the msgs, a replica waits until it has received enough
                // INIT_DONE msgs from all other replicas and clients
                semamanager.wait(SpecialSemaphore(SETUP_DONE), false, false);
                break;
            }
            messager->run();
            semamanager.dec_init_msg_cnt(td_id);
        }
    }
    else{
        while (!simulation->is_setup_done())
        {
            messager->run();
        }
    }
}

```



The **post_all()** method is called when simulation is done. In this method, teh value of every semaphore increases by 1 in case that some threads are stalled by semaphores and then cannot finish.



### A New Way to Count Idle_time of Worker_threads and OutputThreads

With the semaphore optimization, the original to count idle_time is not useful any more since the threads can always successfully dequeue a msg.

```c++
        if (!msg)
        {
            if (idle_starttime == 0)
                idle_starttime = get_sys_clock();
            continue;
        }
        if (idle_starttime > 0)
        {
            INC_STATS(_thd_id, worker_idle_time, get_sys_clock() - idle_starttime);
            idle_starttime = 0;
        }
```

Thus, I come up with a way to count. Only record the time spent waiting for the semaphore, (not completely accurate but enough).

```c++
        if (simulation->is_warmup_done()){
            idle_starttime = get_sys_clock();
        }
        semamanager.wait(td_id, true);
        if (idle_starttime > 0 && simulation->is_warmup_done()){
            output_thd_idle_time[td_id] += get_sys_clock() - idle_starttime;
        }    
```



### Experiment Results

I tested semaphore optimization on AWS machines. For 16-instance RCC with 2 input_threads and 1 output_thread, the throughtput increased from 96k txn/s to 150k txn/s, showing the correctness of this optimization.

I also run PBFT, HOTSTUFF, PVP with semaphore optimization, having solved all bugs found.



If you have any questions, please don't hesitate to let me know.



Dakai Kang

December 19, 2021