### PR TITLE
fix: kv service tools in performance test

### DIFF
--- a/benchmark/protocols/pbft/BUILD
+++ b/benchmark/protocols/pbft/BUILD
@@ -12,3 +12,13 @@ cc_binary(
         "//service/utils:server_factory",
     ],
 )
+
+cc_binary(
+    name = "kv_service_tools",
+    srcs = ["kv_service_tools.cpp"],
+    deps = [
+        "//common/proto:signature_info_cc_proto",
+        "//interface/kv:kv_client",
+        "//platform/config:resdb_config_utils",
+    ],
+)

--- a/benchmark/protocols/pbft/kv_service_tools.cpp
+++ b/benchmark/protocols/pbft/kv_service_tools.cpp
@@ -31,14 +31,14 @@
 #include <fstream>
 
 #include "common/proto/signature_info.pb.h"
+#include "interface/kv/kv_client.h"
 #include "platform/config/resdb_config_utils.h"
-#include "service/kv_service/interface/resdb_kv_client.h"
 
 using resdb::GenerateReplicaInfo;
 using resdb::GenerateResDBConfig;
+using resdb::KVClient;
 using resdb::ReplicaInfo;
 using resdb::ResDBConfig;
-using resdb::ResDBKVClient;
 
 int main(int argc, char** argv) {
   if (argc < 2) {
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
 
   config.SetClientTimeoutMs(100000);
 
-  ResDBKVClient client(config);
+  KVClient client(config);
 
   client.Set("start", "value");
   printf("start benchmark\n");


### PR DESCRIPTION
Hi ResDB team! I found that performance test was not working as expected, as there is no build target for //benchmark/protocols/pbft:kv_service_tools and service/kv_service/interface/resdb_kv_client.h is not found in the repository.
1. add binary for //benchmark/protocols/pbft:kv_service_tools
2. service/kv_service/interface/resdb_kv_client.h is unfound